### PR TITLE
Some NERDTree opts

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -281,6 +281,17 @@ nmap [g :tabprev<return>
 nmap ]g :tabnext<return>
 
 
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" NERDTree
+"
+autocmd StdinReadPre * let s:std_in=1
+autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif
+autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTreeType == "primary") | q | endif
+
+let g:NERDTreeDirArrows = 1
+let g:NERDTreeDirArrowExpandable = "📁"
+let g:NERDTreeDirArrowCollapsible = "📂"
+
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Syntastic configuration

--- a/.vimrc
+++ b/.vimrc
@@ -285,7 +285,9 @@ nmap ]g :tabnext<return>
 " NERDTree
 "
 autocmd StdinReadPre * let s:std_in=1
-autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif
+
+" enable this to run NERDTree when starting vim while argc == 0
+" autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif
 autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTreeType == "primary") | q | endif
 
 let g:NERDTreeDirArrows = 1


### PR DESCRIPTION
Basically just taking the opts that he points out on ['scrooloose/nerdtree'](https://github.com/scrooloose/nerdtree).
- Open nerdtree when running vim
- Kill vim if you `:q` on an open file and NERDTree is the only other thing open.
- Change the arrows to little folders

I like these changes, but feel free to reject (or provide feedback) if you don't.
