### PR TITLE
Fix vim-airline

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -22,7 +22,8 @@ Plugin 'kien/ctrlp.vim'
 Plugin 'terryma/vim-multiple-cursors'
 
 " vim-airline
-Plugin 'bling/vim-airline'
+Plugin 'vim-airline/vim-airline'
+Plugin 'vim-airline/vim-airline-themes'
 
 " vim-fugitive
 Plugin 'tpope/vim-fugitive'


### PR DESCRIPTION
The vim-airline colors were messed up because the repo moved.
